### PR TITLE
Add option to skip stream length check

### DIFF
--- a/src/Serilog.Sinks.File.Header/HeaderWriter.cs
+++ b/src/Serilog.Sinks.File.Header/HeaderWriter.cs
@@ -16,7 +16,7 @@ namespace Serilog.Sinks.File.Header
 
         private readonly Func<string> headerFactory;
 
-        public bool SkipStreamLengthCheck { get; set; }
+		public bool SkipStreamLengthCheck { get; set; }
 
         public HeaderWriter(string header)
         {
@@ -30,7 +30,7 @@ namespace Serilog.Sinks.File.Header
 
         public override Stream OnFileOpened(Stream underlyingStream, Encoding encoding)
         {
-            if (!this.SkipStreamLengthCheck && underlyingStream.Length != 0)
+			if (!this.SkipStreamLengthCheck && underlyingStream.Length != 0)
 			{
 				SelfLog.WriteLine($"File header will not be written, as the stream already contains {underlyingStream.Length} bytes of content");
                 return base.OnFileOpened(underlyingStream, encoding);

--- a/src/Serilog.Sinks.File.Header/HeaderWriter.cs
+++ b/src/Serilog.Sinks.File.Header/HeaderWriter.cs
@@ -14,27 +14,39 @@ namespace Serilog.Sinks.File.Header
         // Same as the default StreamWriter buffer size
         private const int DEFAULT_BUFFER_SIZE = 1014;
 
+        // Factory method to generate the file header
         private readonly Func<string> headerFactory;
 
-		public bool SkipStreamLengthCheck { get; set; }
+        // Whether to always write the header, even for non-empty files
+		private readonly bool alwaysWriteHeader;
 
-        public HeaderWriter(string header)
+        public HeaderWriter(string header, bool alwaysWriteHeader = false)
         {
             this.headerFactory = () => header;
+            this.alwaysWriteHeader = alwaysWriteHeader;
         }
 
-		public HeaderWriter(Func<string> headerFactory)
+		public HeaderWriter(Func<string> headerFactory, bool alwaysWriteHeader = false)
         {
             this.headerFactory = headerFactory;
+            this.alwaysWriteHeader = alwaysWriteHeader;
         }
 
         public override Stream OnFileOpened(Stream underlyingStream, Encoding encoding)
         {
-			if (!this.SkipStreamLengthCheck && underlyingStream.Length != 0)
-			{
-				SelfLog.WriteLine($"File header will not be written, as the stream already contains {underlyingStream.Length} bytes of content");
-                return base.OnFileOpened(underlyingStream, encoding);
-			}
+            try
+            {
+			    if (!this.alwaysWriteHeader && underlyingStream.Length != 0)
+			    {
+				    SelfLog.WriteLine($"File header will not be written, as the stream already contains {underlyingStream.Length} bytes of content");
+                    return base.OnFileOpened(underlyingStream, encoding);
+			    }
+            }
+            catch (NotSupportedException)
+            {
+                // Not all streams support reading the length - in this case, we always write the header, 
+                // otherwise we'd *never* write it!
+            }
 
 			using (var writer = new StreamWriter(underlyingStream, encoding, DEFAULT_BUFFER_SIZE, true))
 			{

--- a/src/Serilog.Sinks.File.Header/HeaderWriter.cs
+++ b/src/Serilog.Sinks.File.Header/HeaderWriter.cs
@@ -16,6 +16,8 @@ namespace Serilog.Sinks.File.Header
 
         private readonly Func<string> headerFactory;
 
+        public bool SkipStreamLengthCheck { get; set; }
+
         public HeaderWriter(string header)
         {
             this.headerFactory = () => header;
@@ -28,7 +30,7 @@ namespace Serilog.Sinks.File.Header
 
         public override Stream OnFileOpened(Stream underlyingStream, Encoding encoding)
         {
-			if (underlyingStream.Length != 0)
+            if (!this.SkipStreamLengthCheck && underlyingStream.Length != 0)
 			{
 				SelfLog.WriteLine($"File header will not be written, as the stream already contains {underlyingStream.Length} bytes of content");
                 return base.OnFileOpened(underlyingStream, encoding);


### PR DESCRIPTION
I'm creating a solution to chain multiple FileLifecycleHooks together so that I can for example have a header and compression by composing existing FileLifecycleHooks together.

The GZip stream does not support getting the Length so this currently fails because of the check in this class.  I've added an option to skip the check (but maybe the class should handle a NotSupportedException on accessing Length?)